### PR TITLE
Hide past order detail on logout or modal close

### DIFF
--- a/assets/scripts/auth/auth-ui.js
+++ b/assets/scripts/auth/auth-ui.js
@@ -77,6 +77,8 @@ const signOutSuccess = function (response) {
   $('.change-password').addClass('hidden')
   $('#see-orders-button').addClass('hidden')
   $('#shopping-cart-button').addClass('hidden')
+  $('#order-detail-detail').html('')
+  $('#order-detail').addClass('hidden')
   ui.showAlert('success', 'Success!', 'We\'ve signed you out and deleted your cart.', 3000)
 }
 

--- a/assets/scripts/orders/orders-events.js
+++ b/assets/scripts/orders/orders-events.js
@@ -12,6 +12,9 @@ const addHandlers = function () {
   $('#cart-items').on('click', '.remove-item-button', processUpdateRequest)
   $('#cart-items-test').on('click', '.remove-item-button', processUpdateRequest)
   $('#past-order-list').on('click', '.show-past-order-button', onShowOrder)
+  $('#orders-close-button').on('click', () => {
+    $('#order-detail').addClass('hidden')
+  })
 }
 
 // display details of past order

--- a/index.html
+++ b/index.html
@@ -177,13 +177,14 @@
               <div id="order-detail-detail">
                 <!-- TO BE FILLED IN BY HANDLEBARS -->
               </div>
-              <button type="button" id="orders-close-button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-            </div>
-            </div>
+            </div> <!-- order-detail -->
+            <button type="button" id="orders-close-button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          </div> <!-- modal-body -->
+
           <p class="auth-alert-modal"></p>
           </div>
           <div class="modal-footer" id="see-orders-modal-footer">
-            <!-- <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button> -->
+
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Refactor `index.html`
- In `signOutSuccess` in `auth-ui.js`, hide the `order-detail` div that
displays past order details so that the next user can't see records that
don't belong to them
- In `orders-events.js`, add an event handler that listens for a click
to close the past orders modal and hides the `order-detail` div so that
by default it does not appear until user clicks again to view a specific
order