### PR TITLE
Sign out modal CSS styling

### DIFF
--- a/assets/scripts/auth/auth-events.js
+++ b/assets/scripts/auth/auth-events.js
@@ -12,7 +12,7 @@ const addHandlers = function () {
   $('#signup-form').on('submit', onSignUp)
   $('#signin-form').on('submit', onSignIn)
   $('#change-password-form').on('submit', onChangePassword)
-  $('.sign-out').on('click', onSignOut)
+  $('#sign-out-button').on('click', onSignOut)
   // clicking out of a modal
   $('button[data-dismiss]').on('click', authUi.clearAuthForms)
 }

--- a/assets/scripts/auth/auth-ui.js
+++ b/assets/scripts/auth/auth-ui.js
@@ -67,6 +67,7 @@ const signOutSuccess = function (response) {
   $('#cart-items').html('')
   delete store.user
   // change which auth options are available
+  $('#signOutModal').modal('hide')
   $('.sign-up').removeClass('hidden')
   $('.sign-in').removeClass('hidden')
   $('.sign-out').addClass('hidden')

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -133,7 +133,7 @@ body {
   cursor: pointer;
 }
 
-#sign-out-button {
+#sign-out-modal-button {
   box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.19);
   display: inline-block;
   border-radius: 4px;
@@ -150,14 +150,14 @@ body {
   height: 30px;
 }
 
-#sign-out-button span {
+#sign-out-modal-button span {
   cursor: pointer;
   display: inline-block;
   position: relative;
   transition: 0.5s;
 }
 
-#sign-out-button span::after {
+#sign-out-modal-button span::after {
   content: '\00bb';
   position: absolute;
   opacity: 0;
@@ -166,11 +166,11 @@ body {
   transition: 0.5s;
 }
 
-#sign-out-button:hover span {
+#sign-out-modal-button:hover span {
   padding-right: 25px;
 }
 
-#sign-out-button:hover span::after {
+#sign-out-modal-button:hover span::after {
   opacity: 1;
   right: 0;
 }

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         </div>
         <div id="header-user-options" class="header">
           <form class="form-inline justify-content-end">
-              <button id="sign-out-button" class="sign-out hidden btn btn-outline-success" type="button"><span>Sign Out</span></button>
+              <button id="sign-out-modal-button" class="sign-out hidden btn btn-outline-success" type="button" data-toggle="modal" data-target="#signOutModal"><span>Sign Out</span></button>
               <button id="change-password-button" class="change-password hidden btn btn-outline-success" data-toggle="modal" data-target="#changePasswordModal" type="button"><span>Change Password</span></button>
               <button id="sign-in-button" class="sign-in btn btn-outline-success" data-toggle="modal" data-target="#signInModal" type="button"><span>Sign In</span></button>
               <button id="sign-up-button" class="sign-up btn btn-outline-success" data-toggle="modal" data-target="#signUpModal" type="button"><span>Sign Up</span></button>
@@ -211,6 +211,28 @@
         </div>
       </div>
     </div>
+
+    <!-- SIGN OUT Modal -->
+                  <div class="modal fade" id="signOutModal" tabindex="-1" role="dialog" aria-labelledby="signOutModalLabel" aria-hidden="true">
+                    <div class="modal-dialog" role="document">
+                      <div class="modal-content">
+                        <div class="modal-header">
+                          <h5 class="modal-title" id="signOutModalLabel">Sign Out</h5>
+                          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                          </button>
+                        </div>
+                        <div class="modal-body">
+                          <p>Signing out will clear your cart. Do you want to continue?</p>
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                          <!-- <button id="sign-out-button" class="sign-out btn btn-outline-success" type="button"><span>Sign Out</span></button> -->
+                          <button id="sign-out-button" class="sign-out btn btn-outline-success">Sign Out</button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
 
     </body>
 


### PR DESCRIPTION
Changes the CSS styling for "#sign-out-button" to apply
  instead to "#sign-out-modal-button" as the tags seem to be
  reversed in the app functionality.

  NOTE: this leaves the buttons inconsistently named (sign-out-button is
  IN the sign out modal and sign-out-modal-button is NOT in the modal)
  but does not interfere with any functionality. Consider
  swapping the two ID tags in the app later if desired.