### PR TITLE
Cart improvements

### DIFF
--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -35,6 +35,7 @@ $(() => {
 
   // when customer clicks 'checkout' button in shopping cart...
   button.addEventListener('click', function (ev) {
+    $('#checkout-alert-modal').html('<strong>Please wait while we process your order through Stripe.</strong>')
     // set `cents` to the value of the button's `data-amount` attribute
     // set `orderId` to the value of the button's `data-order` attribute
     // both of those have been updated each time the cart contents changed
@@ -80,6 +81,7 @@ $(() => {
         // order with no items in it
         if (output.status === 200) {
           $('#shoppingCartModal').modal('hide')
+          $('#checkout-alert-modal').html('')
           ui.showAlert('success', 'Success!', 'Your payment has been processed', 2000)
           $('#buttonCheckout').attr('data-amount', 0)
           $('#buttonCheckout').attr('data-order', 'null')

--- a/assets/scripts/orders/orders-ui.js
+++ b/assets/scripts/orders/orders-ui.js
@@ -38,11 +38,14 @@ const createOrderSuccess = function (response) {
 const displayOrders = function () {
   ordersApi.showOrders()
     .then(response => {
-      // console.log('response.orders from showOrders is: :', response.orders)
-      // console.log('typeof response.orders from showOrders is: :', typeof response.orders)
-      const orderListHtml = orderListHandlebars({ orders: response.orders })
-      $('#past-order-list').html('')
-      $('#past-order-list').html(orderListHtml)
+      if (response.orders.length > 0) {
+        // console.log('response.orders from showOrders is: :', response.orders)
+        // console.log('typeof response.orders from showOrders is: :', typeof response.orders)
+        const orderListHtml = orderListHandlebars({ orders: response.orders })
+        $('#past-order-list').html(orderListHtml)
+      } else {
+        $('#past-order-list').html('You have no past orders to display.')
+      }
     })
     .catch(showOrdersError)
     // .catch(console.error)

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -560,6 +560,12 @@ tr:nth-child(odd) {
   font-size: 25px;
 }
 
+#checkout-alert-modal {
+  font-size: 18px;
+  color: red;
+  font-weight: bold;
+}
+
 .modal-title {
   // background-color: $primeblue-light;
   // font-size: 20px;

--- a/index.html
+++ b/index.html
@@ -199,8 +199,11 @@
               <!-- TO BE FILLED IN BY HANDLEBARS -->
               </div>
             </div>
+            <br>
             <div id="order-total-div">Order Total: $<span class="order-total">Uh oh! No order is loaded!</span></div>
-            <p class="auth-alert-modal"></p>
+            <br>
+            <p><strong>Just testing?</strong> Use card number 4242 4242 4242 4242 with any future expiration date and any 3-digit security code to create a fake payment in Stripe on the next screen.<p>
+            <p id="checkout-alert-modal"></p>
           </div>
           <div class="modal-footer">
             <div id="shop">


### PR DESCRIPTION
- Let user know they have no past orders rather than show an empty table when they click on 'My orders'
- Let user know they can use a fake credit card with Stripe
- When Stripe checkout opens, put note on our own modal to wait for Stripe to close so they don't click on 'checkout' again